### PR TITLE
change arrowParens to always

### DIFF
--- a/prettier-config.js
+++ b/prettier-config.js
@@ -8,6 +8,6 @@ module.exports = {
     jsxSingleQuote: false,
     trailingComma: 'es5',
     bracketSpacing: true,
-    arrowParens: 'avoid',
+    arrowParens: 'always',
     endOfLine: 'lf'
 };


### PR DESCRIPTION
### Description

to quote arguments from
https://prettier.io/docs/en/options.html#arrow-function-parentheses

At first glance, avoiding parentheses may look like a better choice because of
less visual noise. However, when Prettier removes parentheses, it becomes harder
to add type annotations, extra arguments or default values as well as making
other changes. Consistent use of parentheses provides a better developer
experience when editing real code bases, which justifies the default value for
the option.




