### PR TITLE
fix babel eslint problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-import": "^2.25.0",
     "eslint-plugin-prettier": "^3.3.0",
     "eslint-plugin-react": "^7.26.0",
-    "babel-eslint": "^10.0.0",
+    "@babel/eslint-parser": "^7.5.4",
     "prettier": "^2.0.0"
   }
 }


### PR DESCRIPTION
the former doesn't work with require and this caused linter errors on various
react packages using the eslint-config-invenio package
