### PR TITLE
deps: turn dependencies back into normal dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/inveniosoftware/eslint-config-invenio/issues"
   },
   "homepage": "https://github.com/inveniosoftware/eslint-config-invenio#readme",
-  "devDependencies": {
+  "dependencies": {
     "js-yaml": "^3.13.0",
     "eslint": "^8.19.0",
     "eslint-config-prettier": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inveniosoftware/eslint-config-invenio",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "ESLint config/preset used by the Invenio team",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
turning dependencies into dev dependencies causes packages not to be available to the eslint configuration so reverting the change