### PR TITLE
linter: allow expressions in JSX fragment & release: v2.0.2

### DIFF
--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -55,7 +55,9 @@ rules:
   react/jsx-no-comment-textnodes: error
   react/jsx-no-duplicate-props: error
   react/jsx-no-undef: error
-  react/jsx-no-useless-fragment: warn
+  react/jsx-no-useless-fragment:
+    - warn
+    - allowExpressions: true
   react/jsx-pascal-case: error
   react/jsx-props-no-multi-spaces: error
   react/jsx-tag-spacing:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inveniosoftware/eslint-config-invenio",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inveniosoftware/eslint-config-invenio",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "ESLint config/preset used by the Invenio team",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

We get quite a lot of ESLint warnings across `inveniosoftware` repositories for following the pattern `<>{foo}</>`.
There are a few places were we explicitly inline-disable the check, and other places were we ignore the warning.

This pull request proposes to relax this ESLint rule to allow this pattern (see the [`react/jsx-no-useless-fragment` documentation](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md#rule-options)).
Similar pull requests have been opened in:
* `inveniosoftware/react-invenio-app-ils` (https://github.com/inveniosoftware/react-invenio-app-ils/pull/621)
* as well as `inveniosoftware/demo-invenioils` (https://github.com/inveniosoftware/demo-invenioils/pull/17)
* and `inveniosoftware/cookiecutter-invenio-ils` (https://github.com/inveniosoftware/cookiecutter-invenio-ils/pull/3)


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
